### PR TITLE
Implement Rank Aggregator class, Borda count, and Schulze method

### DIFF
--- a/mclearn/aggregators.py
+++ b/mclearn/aggregators.py
@@ -1,0 +1,88 @@
+""" Rank aggregators. """
+
+import itertools
+import functools
+import numpy as np
+
+
+def borda_count(voters, n_candidates):
+    """ Borda count rank aggregator.
+
+        Parameters
+        ----------
+        voters : list-like
+            A list of arrays where each array correponds to a voter's preference.
+
+        n_candidates : int
+            The number of best candidates to be selected at each iteration.
+
+        Returns
+        -------
+        best_candidates : array
+            The list of indices of the best candidates.
+    """
+
+    max_score = len(voters[0])
+    points = {}
+
+    # accumulate the points for each candidate
+    for voter in voters:
+        for idx, candidate in enumerate(voter):
+            points[candidate] = points.get(candidate, 0) + max_score - idx
+
+    # sort the candidates and return the most popular one(s)
+    rank = sorted(points, key=points.__getitem__, reverse=True)
+    return rank[:n_candidates]
+
+
+def schulze_method(voters, n_candidates):
+    """ Schulze method of ordering candidates.
+
+        Parameters
+        ----------
+        voters : list-like
+            A list of arrays where each array correponds to a voter's preference.
+
+        n_candidates : int
+            The number of best candidates to be selected at each iteration.
+
+        Returns
+        -------
+        best_candidates : array
+            The list of indices of the best candidates.
+    """
+
+    points = {}
+    candidates = set()
+
+    for voter in voters:
+        for idx_i in range(len(voter)):
+            for idx_j in range(idx_i + 1, len(voter)):
+                i = voter[idx_i]
+                j = voter[idx_j]
+                points[(i, j)] = points.get((i, j), 0) + 1
+
+    # get the id of all candidates
+    candidates = set(itertools.chain(*points.keys()))
+
+    # compute the strogest path using a variant of Floyd–Warshall algorithm
+    strength = {}
+    for i, j in itertools.product(candidates, repeat=2):
+        if i != j:
+            points.setdefault((i, j), 0)
+            points.setdefault((j, i), 0)
+            if points[(i, j)] > points[(j, i)]:
+                strength[(i, j)] = points[(i, j)]
+            else:
+                strength[(i, j)] = 0
+
+    # k is the expanding set of intermediate nodes in Floyd-Warshall
+    for k, i, j in itertools.product(candidates, repeat=3):
+        if (i != j) and (k != i) and (k != j):
+            strength[(i, j)] = max(strength[(i, j)], min(strength[(i, k)], strength[(k, j)]))
+
+    # Schulze method guarantees that there is no cycle, so sorting is well-defined
+    compare_strength = lambda x, y: strength[(x, y)] - strength[(y, x)]
+    rank = sorted(candidates, key=functools.cmp_to_key(compare_strength))
+    return rank[:n_candidates]
+

--- a/mclearn/heuristics.py
+++ b/mclearn/heuristics.py
@@ -27,6 +27,7 @@ def random_h(candidate_mask, n_candidates, **kwargs):
     """
     
     candidate_index = np.where(candidate_mask)[0]
+    n_candidates = min(n_candidates, len(candidate_index))
     random_index = np.random.choice(candidate_index, n_candidates, replace=False)
     return random_index
 
@@ -66,6 +67,9 @@ def entropy_h(X, candidate_mask, classifier, n_candidates, **kwargs):
     shannon = np.empty(len(candidate_mask))
     shannon[:] = -np.inf
     shannon[candidate_mask] = candidate_shannon
+
+    # make sure we don't return non-candidates
+    n_candidates = min(n_candidates, len(probs))
     
     # pick the candidate with the greatest Shannon entropy
     best_candidates = np.argsort(-shannon)[:n_candidates]
@@ -112,6 +116,9 @@ def margin_h(X, candidate_mask, classifier, n_candidates, **kwargs):
     margin = np.empty(len(candidate_mask))
     margin[:] = +np.inf
     margin[candidate_mask] = candidate_margin
+
+    # make sure we don't return non-candidates
+    n_candidates = min(n_candidates, len(probs))
     
     # pick the candidate with the smallest margin
     best_candidates = np.argsort(margin)[:n_candidates]
@@ -188,6 +195,9 @@ def qbb_margin_h(X, y, candidate_mask, train_mask, n_candidates, committee,
     margin = np.empty(len(candidate_mask))
     margin[:] = +np.inf
     margin[candidate_mask] = candidate_margin
+
+    # make sure we don't return non-candidates
+    n_candidates = min(n_candidates, n_samples)
     
     # pick the candidate with the smallest margin
     best_candidates = np.argsort(margin)[:n_candidates]
@@ -274,6 +284,9 @@ def qbb_kl_h(X, y, candidate_mask, train_mask, n_candidates, committee, committe
     kl = np.empty(len(candidate_mask))
     kl[:] = -np.inf
     kl[candidate_mask] = avg_kl
+
+    # make sure we don't return non-candidates
+    n_candidates = min(n_candidates, n_samples)
     
     # pick the candidate with the smallest margin
     best_candidates = np.argsort(-kl)[:n_candidates]
@@ -461,6 +474,9 @@ def pool_variance_h(X, y, candidate_mask, train_mask, classifier, n_candidates,
     assert not np.isnan(expected).any(), 'Some expected values are undefined.'
     variance[indices] = expected
 
+    # make sure we don't return non-candidates
+    n_candidates = min(n_candidates, len(probs))
+
     # pick the candidate with the smallest expected variance
     best_candidates = np.argsort(variance)[:n_candidates]
     return best_candidates
@@ -559,6 +575,9 @@ def pool_entropy_h(X, y, candidate_mask, train_mask, classifier, n_candidates,
     assert not np.isnan(expected).any(), 'Some expected values are undefined.'
 
     entropy[indices] = expected
+
+    # make sure we don't return non-candidates
+    n_candidates = min(n_candidates, len(probs))
 
     # pick the candidate with the smallest expected entropy
     best_candidates = np.argsort(entropy)[:n_candidates]


### PR DESCRIPTION
The Rank Aggregator class allows us to run active learning using a custom rank aggregation method. Two methods have been implemented so far:

* Borda count (where each candidate is given a point based on their rank)
* Schulze method (a type of the pairwise majority rule that uses a variant of the Floyd–Warshall algorithm to rank candidate pairs).